### PR TITLE
Post-processing example scripts

### DIFF
--- a/Stress_strain_curve_plotting.py
+++ b/Stress_strain_curve_plotting.py
@@ -1,0 +1,25 @@
+import h5py
+import numpy as np
+import amtplotlib.pyplot as plt
+
+stress_list = []
+strain_list = []
+incs_list = []
+
+d = damask.Result(i)
+
+d.add_stress_Cauchy()
+d.add_strain()
+d.add_equivalent_Mises('sigma')
+d.add_equivalent_Mises('epsilon_V^0.0(F)')
+            
+f = h5py.File(d.fname)
+            
+for path in d.get_dataset_location('sigma_vM'):
+    incs_list.append(path.split('/')[0])
+    stress_list.append(np.average(f[path]))
+for path in d.get_dataset_location('epsilon_V^0.0(F)_vM'):
+    strain_list.append(np.average(f[path]))
+
+
+plt.plot(strain_list, stress_list)

--- a/ori_script.m
+++ b/ori_script.m
@@ -1,0 +1,40 @@
+%% Import Script for ODF Data
+%
+% This script was automatically created by the import wizard. You should
+% run the whoole script or parts of it in order to import your data. There
+% is no problem in making any changes to this script.
+
+%% Specify Crystal and Specimen Symmetries
+
+% crystal symmetry
+CS = crystalSymmetry('m-3m', [3.7 3.7 3.7], 'mineral', 'Iron');
+
+% specimen symmetry
+SS = specimenSymmetry('mmm');
+
+% plotting convention
+setMTEXpref('xAxisDirection','north');
+setMTEXpref('zAxisDirection','outOfPlane');
+
+%% Specify File Names
+
+% path to files
+pname = 'L:\DRX_sample_simulations\Industrial_finishing_mill\simulation\postProc';
+
+% which files to be imported
+fname = [pname '\MDRX_ori_29000.txt'];
+
+%% Import the Data
+
+% specify kernel
+psi = deLaValleePoussinKernel('halfwidth',5*degree);
+
+% load the ODF into the variable odf
+odf = ODF.load(fname,CS,SS,'density','kernel',psi,'resolution',5*degree,...
+  'interface','generic',...
+  'ColumnNames', { 'phi1' 'Phi' 'phi2'}, 'Bunge', 'Radians');
+
+setMTEXpref('FontSize',28);
+plot(odf,'phi2',[45]*degree,'contourf','silent','colorrange',[0,14]);
+mtexColorMap LaboTeX;
+mtexColorbar;


### PR DESCRIPTION
Following things can be done now:
1. Plot stress strain curve from DAMASK data
2. Plot ODF from the orientation data out of DAMASK or CASIPT

To plot the recrystallization fraction curves, there is a file which ends with 'fractions.txt' in the CASIPT outputs, that has first column as time and second column as fractions, so you can plot that directly. 

For the presentation currently, I guess we can compare the these 3 outputs from the example simulations that were performed. 